### PR TITLE
Stop using deprecated interface from SQLA 1.3

### DIFF
--- a/flask_sqlalchemy/__init__.py
+++ b/flask_sqlalchemy/__init__.py
@@ -166,7 +166,7 @@ class SignallingSession(SessionBase):
     def get_bind(self, mapper=None, clause=None):
         # mapper is None if someone tries to just get a connection
         if mapper is not None:
-            info = getattr(mapper.mapped_table, 'info', {})
+            info = getattr(mapper.persist_selectable, "info", {})
             bind_key = info.get('bind_key')
             if bind_key is not None:
                 state = get_state(self.app)


### PR DESCRIPTION
See https://github.com/sqlalchemy/sqlalchemy/issues/4586 and https://docs.sqlalchemy.org/en/13/orm/mapping_api.html#sqlalchemy.orm.mapper.Mapper.mapped_table